### PR TITLE
main.adoc: rename test-report.adoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # This file will be modified by the script
 include/test-reports.adoc
 # Pdf generated
-main.pdf
+test-report.pdf
 # All included xml test files
 include/*.xml

--- a/compile.sh
+++ b/compile.sh
@@ -179,6 +179,6 @@ if [ -z "$SRC_DIR" ] || [ ! -d "$SRC_DIR" ] ; then
 fi
 
 integrate_all
-asciidoctor-pdf main.adoc
+asciidoctor-pdf test-report.adoc
 
 rm $TEST_ADOC_FILE

--- a/test-report.adoc
+++ b/test-report.adoc
@@ -36,7 +36,7 @@ In order to generate an HTML version of this documentation, use the following
 command (the asciidoc package will need to be installed in your Linux
 distribution):
 
-  $ asciidoc main.adoc
+  $ asciidoc test-report.adoc
 
 This will result in a README.html file being generated in the current directory.
 
@@ -44,4 +44,4 @@ If you prefer a PDF version of the documentation instead, use the following
 command (the dblatex package will need to be installed on your Linux
 distribution):
 
-  $ asciidoctor-pdf main.adoc
+  $ asciidoctor-pdf test-report.adoc


### PR DESCRIPTION
The output file name was main.pdf which may be confusing among other pdf files. Typically, our CI creates a README.pdf, so it's not clear what main.pdf may contain. Use a more accurate name.