### PR TITLE
compile.py: return error when test is absent

### DIFF
--- a/examples/complex/matrix.csv
+++ b/examples/complex/matrix.csv
@@ -4,4 +4,3 @@ Requirement b,ID 2
 Requirement c,ID 7
 Requirement c,ID 4
 Requirement c,ID 9
-Requirement c,ID 10


### PR DESCRIPTION
Print a log if a test is absent.
Return error in that case.