### PR TITLE
themes: add a line break after the receiver name in the title page

### DIFF
--- a/themes/theme.yml
+++ b/themes/theme.yml
@@ -29,7 +29,7 @@ title_page:
     margin-top: 40
     content:
       with_email: |
-          Receiver: {author}
+          Receiver: {author} +
           Contact: <{email}>
     font-color: #181818
 code:


### PR DESCRIPTION
This is a minor change to the default theme that adds a line break after the receiver name in the title page.

Change-Id: I3c826dd4e7e6b2a392bc18b79c94364cd28a3f4e