### PR TITLE
compile.py: update check_for_id behavior

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -201,14 +201,14 @@ def generate_adoc(xml_files):
 
 def check_for_id(suite):
     """
-    Check in the first test if there is an id. If yes return True otherwise
+    Check if an ID is used in one of the test. If yes return True otherwise
     return False
     """
     for test in suite:
         if CukiniaTest.fromelem(test).get_property_value("cukinia.id"):
             return True
-        else:
-            return False
+
+    return False
 
 
 def write_table_header(suite, adoc_file, has_test_id):


### PR DESCRIPTION
The check_for_id function only checked the first test to see if the test ID was used. Therefore, if one of the tests didn't use an ID, the behavior was different depending on whether it was the first in the suite or not.

The test ID column is now added as soon as a test of a suite has an ID.