### PR TITLE
themes: add support for title page background image

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -8,7 +8,7 @@ command=' \
     && ./compile.py -i examples/simple -C SFL -p simple_example \
     && mv test-report.pdf simple-example.pdf \
     && cukinia -f junitxml -o examples/complex/results.xml examples/complex/cukinia.conf || true \
-    && ./compile.py -i examples/complex -m -c examples/complex/matrix.csv -C SFL -p complex_example \
+    && ./compile.py -i examples/complex -m -c examples/complex/matrix.csv -C SFL -p complex_example --title_background_image themes/background.svg \
     && mv test-report.pdf complex-example.pdf \
 '
 flavors='sonarqube'

--- a/compile.py
+++ b/compile.py
@@ -136,6 +136,14 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        "-b",
+        "--title_background_image",
+        help="""Path to an image file to use as the title page background.""",
+        type=str,
+        default=None,
+    )
+
+    parser.add_argument(
         "--allow_absent",
         help="""Allow absent tests in the compliance matrix. WARNING: you won't"""
         """ be notified again that some tests are absents.""",
@@ -585,6 +593,11 @@ try:
     date = datetime.now().astimezone().strftime("%-d %B %Y, %H:%M:%S %Z")
     year = datetime.now().astimezone().strftime("%Y")
 
+    background_arg = ""
+    if args.title_background_image:
+        bg_path = os.path.abspath(args.title_background_image)
+        background_arg = f"-a title-page-background-image=image:{bg_path}[]"
+
     os.system(
         f"asciidoctor-pdf \
             -r ./extended-pdf-converter.rb \
@@ -595,6 +608,7 @@ try:
             -a email='{args.contact_email}' \
             -a pdf-themesdir='{args.pdf_themes_dir}' \
             -a pdf-theme='{args.pdf_theme}' \
+            {background_arg} \
             test-report.adoc"
     )
 finally:

--- a/themes/background.svg
+++ b/themes/background.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="595" height="842" viewBox="0 0 595 842">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a7fa0"/>
+      <stop offset="100%" stop-color="#56b0c9"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="595" height="842" fill="url(#bg)"/>
+
+  <!-- Top-left decorative block -->
+  <rect x="0" y="0" width="180" height="8" fill="#ffffff" opacity="0.15"/>
+
+  <!-- Bottom accent bar -->
+  <rect x="0" y="800" width="595" height="42" fill="#1a5f7a" opacity="0.6"/>
+
+  <!-- Diagonal decorative lines -->
+  <line x1="0" y1="842" x2="200" y2="580" stroke="#ffffff" stroke-width="1" opacity="0.1"/>
+  <line x1="0" y1="842" x2="350" y2="580" stroke="#ffffff" stroke-width="1" opacity="0.1"/>
+  <line x1="0" y1="842" x2="500" y2="580" stroke="#ffffff" stroke-width="1" opacity="0.1"/>
+  <line x1="595" y1="842" x2="395" y2="580" stroke="#ffffff" stroke-width="1" opacity="0.1"/>
+
+  <!-- Large circle, bottom-right -->
+  <circle cx="520" cy="720" r="160" fill="#ffffff" opacity="0.04"/>
+  <circle cx="520" cy="720" r="110" fill="#ffffff" opacity="0.04"/>
+
+  <!-- Small circle, top-right -->
+  <circle cx="540" cy="80" r="60" fill="#ffffff" opacity="0.06"/>
+</svg>

--- a/themes/theme.yml
+++ b/themes/theme.yml
@@ -16,6 +16,8 @@
 extends: default
 title_page:
   background_color: #56b0c9
+  # Uncomment and set path (relative to pdf-themesdir) to use a background image:
+  #background_image: image:background.svg[]
   align: center
   logo:
     image: image:sfl.png[width=30%, align=center]


### PR DESCRIPTION
The compile.py script now accepts an optional argument --title_background_image, which allows users to specify an image file to be used as the background for the title page of the generated PDF report.

The .cqfdrc configuration file has been updated to demonstrate how to use this new feature, and a sample background image (background.svg) has been added to the themes directory.

The theme.yml file has also been updated with a commented-out example of how to set a background image for the title page using the pdf theme configuration.