### PR TITLE
compile.py: add option to include output messages for failed tests

### DIFF
--- a/.cqfdrc
+++ b/.cqfdrc
@@ -5,10 +5,10 @@ name='test-report-pdf'
 [build]
 command=' \
     cukinia -f junitxml -o examples/simple/results.xml examples/simple/cukinia.conf || true \
-    && ./compile.py -i examples/simple -C SFL -p simple_example \
+    && ./compile.py -i examples/simple -C SFL -p simple_example --show_failed_cdata \
     && mv test-report.pdf simple-example.pdf \
     && cukinia -f junitxml -o examples/complex/results.xml examples/complex/cukinia.conf || true \
-    && ./compile.py -i examples/complex -m -c examples/complex/matrix.csv -C SFL -p complex_example --title_background_image themes/background.svg \
+    && ./compile.py -i examples/complex -m -c examples/complex/matrix.csv -C SFL -p complex_example --title_background_image themes/background.svg --show_failed_cdata \
     && mv test-report.pdf complex-example.pdf \
 '
 flavors='sonarqube'

--- a/compile.py
+++ b/compile.py
@@ -22,6 +22,7 @@ import os
 import sys
 import textwrap
 from junitparser import TestCase, JUnitXml, Properties
+from junitparser.junitparser import SystemErr, SystemOut
 from datetime import datetime
 
 ADOC_FILE_PATH = "test-report-content.adoc"
@@ -47,6 +48,12 @@ class CukiniaTest(TestCase):
             if prop.name == name:
                 return prop.value
         return None
+
+    def get_section(self, section_type):
+        """
+        Gets a section (system-out or system-err) from a testcase.
+        """
+        return self.child(section_type)
 
 
 def die(error_string):
@@ -151,6 +158,13 @@ def parse_arguments():
         default=False,
     )
 
+    parser.add_argument(
+        "--show_failed_cdata",
+        help="""Show system-out and system-err content for failed tests.""",
+        action="store_true",
+        default=False,
+    )
+
     return parser.parse_args()
 
 
@@ -214,6 +228,8 @@ def generate_adoc(xml_files):
         os.remove(ADOC_FILE_PATH)
 
     with open(ADOC_FILE_PATH, "w", encoding="utf-8") as adoc_file:
+        failed_outputs = []
+
         adoc_file.write(
             "include::{}/prerequisites.adoc[opts=optional]\n\n".format(args.include_dir)
         )
@@ -239,12 +255,16 @@ def generate_adoc(xml_files):
                         adoc_file,
                         has_test_id,
                         assigned_anchors,
+                        failed_outputs,
                     )
                 write_table_footer(suite, adoc_file)
 
         return_code = 0
         if args.compliance_matrix:
             return_code = add_compliance_matrix(xml_files, adoc_file)
+
+        if args.show_failed_cdata:
+            write_failed_cdata_annex(failed_outputs, adoc_file)
 
         adoc_file.write(
             "include::{}/notes.adoc[opts=optional]\n".format(args.include_dir)
@@ -304,7 +324,9 @@ def write_table_header(suite, adoc_file, has_test_id):
         )
 
 
-def write_table_line(test, adoc_file, has_test_id, assigned_anchors):
+def write_table_line(
+    test, adoc_file, has_test_id, assigned_anchors, failed_outputs
+):
 
     table_line_test_id = textwrap.dedent(
         """
@@ -356,14 +378,87 @@ def write_table_line(test, adoc_file, has_test_id, assigned_anchors):
             )
         )
     else:
+        failure_anchor = ""
+        result_text = "FAIL"
+
+        if args.show_failed_cdata:
+            failure_anchor = register_failed_output(test, failed_outputs)
+            if failure_anchor:
+                result_text = f"<<{failure_anchor},FAIL>>"
+
         adoc_file.write(
             table_line.format(
                 _testanchor_=test_anchor,
                 _testname_=test.name.replace("|", "\\|"),
-                _result_="FAIL",
+                _result_=result_text,
                 _color_=RED_COLOR,
             )
         )
+
+
+def register_failed_output(test, failed_outputs):
+
+    outputs = []
+    for section_type, section_name in ((SystemOut, "system-out"), (SystemErr, "system-err")):
+        section = test.get_section(section_type)
+        if section is None or section.text is None or not section.text.strip():
+            continue
+        outputs.append((section_name, section.text.rstrip()))
+
+    if not outputs:
+        return ""
+
+    failure_anchor = f"failed-output-{len(failed_outputs) + 1}"
+    failed_outputs.append(
+        {
+            "anchor": failure_anchor,
+            "classname": test.classname,
+            "name": test.name,
+            "test_id": test.get_property_value("cukinia.id"),
+            "outputs": outputs,
+        }
+    )
+    return failure_anchor
+
+
+def write_failed_cdata_annex(failed_outputs, adoc_file):
+
+    if not failed_outputs:
+        return
+
+    adoc_file.write("== Failed tests output\n")
+    adoc_file.write("{{set:cellbgcolor!}}\n")
+    for item in failed_outputs:
+        item_name = item["name"].replace("|", "\\|")
+        title = item_name
+        if args.add_machine_name:
+            title = f"{item['classname']} / {title}"
+        if item.get("test_id"):
+            title = f"{title} ({item['test_id']})"
+        adoc_file.write(
+            textwrap.dedent(
+                f"""
+
+                [[{item['anchor']}]]
+                === {title}
+                [options="header",cols="1,9",frame=all,grid=all]
+                |===
+                |Type |Output
+                """
+            )
+        )
+        for section_name, content in item["outputs"]:
+            escaped_content = content.replace("|", "\\|").replace("\n", " pass:[<br>] ")
+            adoc_file.write(
+                textwrap.dedent(
+                    f"""
+
+                    |{section_name}
+                    |{escaped_content}
+                    """
+                )
+            )
+        adoc_file.write("|===\n")
 
 
 def write_table_footer(suite, adoc_file):

--- a/examples/complex/cukinia.conf
+++ b/examples/complex/cukinia.conf
@@ -29,3 +29,5 @@ test_id "ID 6" as "Python package math is installed" cukinia_python_pkg math
 test_id "ID 7" as "google is accessble" cukinia_http_request www.google.com
 test_id "ID 8" as "sysfs on /sys works" cukinia_mount sysfs /sys sysfs rw
 test_id "ID 9" as "symlink to /etc/network/interfaces exists" cukinia_symlink /etc/network/interfaces /tmp/interfaces
+test_id "ID 10" as "Verbose test hello" verbose cukinia_cmd echo "Hello, Cukinia!"
+test_id "ID 11" as "Verbose test fail" verbose cukinia_cmd /bin/sh -c 'echo "This test will fail" && echo "This is a second line of output" && echo >&2 "Error: This test is failing" && /bin/false'

--- a/examples/simple/cukinia.conf
+++ b/examples/simple/cukinia.conf
@@ -14,3 +14,5 @@ cukinia_http_request http://127.0.0.1:81/
 cukinia_python_pkg nonexistent
 not cukinia_mount /dev/nonex /nodir noopt
 cukinia_symlink /etc/network/interfaces nonexistent
+verbose cukinia_cmd echo "Hello, Cukinia!"
+verbose cukinia_cmd /bin/sh -c 'echo "This test will fail" && echo "This is a second line of output" && echo >&2 "Error: This test is failing" && /bin/false'


### PR DESCRIPTION
Cukinia is able to capture the output of tests (both stdout and stderr) in the JUnit XML report. This commit adds an option to include this output in the generated documentation for failed tests, which can be very helpful for understanding the reasons for test failures.

<img width="1177" height="631" alt="image" src="https://github.com/user-attachments/assets/40cf2d66-8032-46de-89cd-e8a63371ae64" />
<img width="1180" height="460" alt="image" src="https://github.com/user-attachments/assets/c7c7042c-ad8d-4d35-b03a-b3688ba4b84c" />
