### PR TITLE
themes: add support for subtitle

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -157,6 +157,13 @@ def parse_arguments():
     )
 
     parser.add_argument(
+        "--subtitle",
+        help="""Subtitle to be shown on the title page.""",
+        type=str,
+        default='',
+    )
+
+    parser.add_argument(
         "--allow_absent",
         help="""Allow absent tests in the compliance matrix. WARNING: you won't"""
         """ be notified again that some tests are absents.""",
@@ -713,6 +720,7 @@ try:
             -a email='{args.contact_email}' \
             -a pdf-themesdir='{args.pdf_themes_dir}' \
             -a pdf-theme='{args.pdf_theme}' \
+            -a subtitle='{args.subtitle}' \
             {background_arg} \
             test-report.adoc"
     )

--- a/test-report.adoc
+++ b/test-report.adoc
@@ -17,7 +17,7 @@
 :pdf-theme: themes/theme.yml
 :doctype: book
 
-= Test report {project}
+= Test report {project}: {subtitle}
 :toc:
 :icons:
 :iconsdir: ./doc/icons/

--- a/themes/theme.yml
+++ b/themes/theme.yml
@@ -27,6 +27,9 @@ title_page:
     font_color: #ffffff
     line_height: 0.9
     text-transform: uppercase
+  subtitle:
+    font_color: #ffffff
+    line_height: 0.9
   authors:
     margin-top: 40
     content:


### PR DESCRIPTION
Displays under the title, like this:
<img width="403" height="347" alt="image" src="https://github.com/user-attachments/assets/9c689abd-c6de-4825-8224-5f9359e12412" />
